### PR TITLE
feat(rename_title): Add NAME column to database migration

### DIFF
--- a/db/migrations/20191111082639_add_name_to_movies.js
+++ b/db/migrations/20191111082639_add_name_to_movies.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = async (knex) => {
+  await knex.schema.table('movies', (table) => {
+    table.text('name');
+  });
+  await knex.raw('ALTER TABLE movies ALTER COLUMN title DROP NOT NULL');
+};
+
+exports.down = async (knex) => {
+  await knex.schema.table('movies', (table) => {
+    table.dropColumn('name');
+  });
+  await knex.raw('ALTER TABLE movies ALTER COLUMN title SET NOT NULL');
+};


### PR DESCRIPTION
What: Add NAME column to the database migration
Why: Necessary first step to renaming TITLE column to NAME
Details:

* Add migration file that adds NAME column to the database