### PR TITLE
feat(rename_title): Backfill NAME column

### DIFF
--- a/db/migrations/20191111083934_backfill_movies_name.js
+++ b/db/migrations/20191111083934_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = (knex) => {
+  return knex.raw('UPDATE movies SET name = title');
+};
+
+exports.down = (knex, Promise) => {
+  return Promise.resolve();
+};

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,7 +3,7 @@
 const Movie = require('../../../models/movie');
 
 exports.create = async (payload) => {
-  const movie = await new Movie().save(payload);
+  const movie = await Movie.forge({ name: payload.title }).save(payload);
 
   return new Movie({ id: movie.id }).fetch();
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "db:seed": "yarn db:reset && knex seed:run --knexfile db/index.js",
     "db:setup": "if [ \"$NODE_ENV\" != \"production\" ]; then createdb -O $(node -e \"var c = require('./config'); console.log(c.DB_USER, c.DB_NAME);\"); fi",
     "db:setup:user": "if [ \"$NODE_ENV\" != \"production\" ]; then createuser $(node -p \"require('./config').DB_USER\"); fi",
+    "debug": "nodemon --inspect --ignore test/",
     "enforce": "istanbul check-coverage --statement 100 --branch 100 --function 100 --lines 100",
     "lint": "eslint .",
     "release:major": "changelog -M && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && yarn version --new-version major && git push origin && git push origin --tags",


### PR DESCRIPTION
What: Backfills NAME column from the data from the TITLE Column
Why: This is necessary because TITLE column was required to be non-null
Details:

* Adds a yarn script for debugging
* Adds a way for future TITLEs to be added to the NAME column
* Updates the movies table to set all current NAME fields to the corresponding TITLE field

Notes:

* `feat(rename_title): Add NAME column to database migration` is being reviewed in #7 