### PR TITLE
feat(get_movies): Added GET /movies endpoint and tests

### DIFF
--- a/db/migrations/20191111083934_backfill_movies_name.js
+++ b/db/migrations/20191111083934_backfill_movies_name.js
@@ -4,6 +4,6 @@ exports.up = (knex) => {
   return knex.raw('UPDATE movies SET name = title');
 };
 
-exports.down = (knex, Promise) => {
+exports.down = () => {
   return Promise.resolve();
 };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -15,8 +15,7 @@ exports.get = async (request) => {
   const params = request.query;
 
   return await new Movie().query((builder) => {
-    const titleMatcher = params.exactTitle === 'true' ? '=' : 'LIKE';
-
+    const titleMatcher = params.exact ? '=' : 'LIKE';
     let title;
 
     if (titleMatcher === '=') {
@@ -25,13 +24,16 @@ exports.get = async (request) => {
       title = `%${params.title}%`;
     }
 
-    if (params.exactYear) {
+    if (params.year) {
       builder.where('release_year', '=', params.year);
-    } else {
-      builder
-      .where('release_year', '>=', params.startYear)
-      .where('release_year', '<=', params.endYear);
     }
+    if (params.startYear) {
+      builder.where('release_year', '>=', params.startYear);
+    }
+    if (params.endYear) {
+      builder.where('release_year', '<=', params.endYear);
+    }
+
     builder.where('name', titleMatcher, title);
   })
   .fetchAll();

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -10,3 +10,25 @@ exports.create = async (payload) => {
 
   return new Movie({ id: movie.id }).fetch();
 };
+
+exports.get = async (request) => {
+  const params = request.query;
+
+  return await new Movie().query((builder) => {
+    const matcher = params.exact === 'true' ? '=' : 'LIKE';
+
+    let title;
+
+    if (matcher === '=') {
+      title = params.title;
+    } else {
+      title = `%${params.title ? params.title : ''}%`;
+    }
+
+    builder
+    .where('release_year', '>', params.startYear ? params.startYear : '1878')
+    .andWhere('release_year', '<', params.endYear ? params.endYear :  '9999')
+    .andWhere('name', matcher, title);
+  })
+  .fetchAll();
+};

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -15,20 +15,24 @@ exports.get = async (request) => {
   const params = request.query;
 
   return await new Movie().query((builder) => {
-    const matcher = params.exact === 'true' ? '=' : 'LIKE';
+    const titleMatcher = params.exactTitle === 'true' ? '=' : 'LIKE';
 
     let title;
 
-    if (matcher === '=') {
+    if (titleMatcher === '=') {
       title = params.title;
     } else {
       title = `%${params.title}%`;
     }
 
-    builder
-    .where('release_year', '>=', params.startYear)
-    .andWhere('release_year', '<=', params.endYear)
-    .andWhere('name', matcher, title);
+    if (params.exactYear) {
+      builder.where('release_year', '=', params.year);
+    } else {
+      builder
+      .where('release_year', '>=', params.startYear)
+      .where('release_year', '<=', params.endYear);
+    }
+    builder.where('name', titleMatcher, title);
   })
   .fetchAll();
 };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -22,12 +22,12 @@ exports.get = async (request) => {
     if (matcher === '=') {
       title = params.title;
     } else {
-      title = `%${params.title ? params.title : ''}%`;
+      title = `%${params.title}%`;
     }
 
     builder
-    .where('release_year', '>', params.startYear ? params.startYear : '1878')
-    .andWhere('release_year', '<', params.endYear ? params.endYear :  '9999')
+    .where('release_year', '>=', params.startYear)
+    .andWhere('release_year', '<=', params.endYear)
     .andWhere('name', matcher, title);
   })
   .fetchAll();

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const Controller     = require('./controller');
-const MovieValidator = require('../../../validators/movie');
+const Controller        = require('./controller');
+const MovieValidator    = require('../../../validators/movie');
+const MovieGetValidator = require('../../../validators/getMovie');
 
 exports.register = (server, options, next) => {
   server.route([{
@@ -23,6 +24,9 @@ exports.register = (server, options, next) => {
     config: {
       handler: (request, reply) => {
         reply(Controller.get(request));
+      },
+      validate: {
+        query: MovieGetValidator
       }
     }
   }]);

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -17,6 +17,16 @@ exports.register = (server, options, next) => {
     }
   }]);
 
+  server.route([{
+    method: 'GET',
+    path: '/movies',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.get(request));
+      }
+    }
+  }]);
+
   next();
 
 };

--- a/lib/validators/getMovie.js
+++ b/lib/validators/getMovie.js
@@ -2,9 +2,15 @@
 
 const Joi = require('joi');
 
-module.exports = {
-  exact: Joi.boolean().default(false),
-  title: Joi.string().min(1).max(255).default(''),
-  startYear: Joi.number().min(1878).default(1878),
-  endYear: Joi.number().max(9999).default(9999)
-};
+module.exports = Joi.object().keys({
+  exactTitle: Joi.boolean().default(false),
+  exactYear: Joi.boolean().default(false),
+  title: Joi.string().max(255).default(''),
+  startYear: Joi.number().integer().min(1878).default(1878),
+  endYear: Joi.number().integer().max(9999).default(9999),
+  year: Joi.when(Joi.ref('exactYear'), {
+    is: Joi.boolean().valid(true).required(),
+    then: Joi.number().integer().min(1878).max(9999).required(),
+    otherwise: Joi.any()
+  })
+});

--- a/lib/validators/getMovie.js
+++ b/lib/validators/getMovie.js
@@ -1,16 +1,11 @@
 'use strict';
 
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
-module.exports = Joi.object().keys({
-  exactTitle: Joi.boolean().default(false),
-  exactYear: Joi.boolean().default(false),
+module.exports = Joi.object({
+  exact: Joi.boolean().falsy('N').truthy('true').default(false),
   title: Joi.string().max(255).default(''),
-  startYear: Joi.number().integer().min(1878).default(1878),
-  endYear: Joi.number().integer().max(9999).default(9999),
-  year: Joi.when(Joi.ref('exactYear'), {
-    is: Joi.boolean().valid(true).required(),
-    then: Joi.number().integer().min(1878).max(9999).required(),
-    otherwise: Joi.any()
-  })
-});
+  startYear: Joi.number().integer().min(1878),
+  endYear: Joi.number().integer().max(9999),
+  year: Joi.number().integer().min(1878).max(9999)
+}).oxor('startYear', 'year').oxor('endYear', 'year');

--- a/lib/validators/getMovie.js
+++ b/lib/validators/getMovie.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = {
+  exact: Joi.boolean().default(false),
+  title: Joi.string().min(1).max(255).default(''),
+  startYear: Joi.number().min(1878).default(1878),
+  endYear: Joi.number().max(9999).default(9999)
+};

--- a/lib/validators/getMovie.js
+++ b/lib/validators/getMovie.js
@@ -3,7 +3,7 @@
 const Joi = require('@hapi/joi');
 
 module.exports = Joi.object({
-  exact: Joi.boolean().falsy('N').truthy('true').default(false),
+  exact: Joi.boolean().default(false),
   title: Joi.string().max(255).default(''),
   startYear: Joi.number().integer().min(1878),
   endYear: Joi.number().integer().max(9999),

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 module.exports = Joi.object().keys({
   title: Joi.string().min(1).max(255).required(),

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "hapi": "16.6.1",
     "hapi-bookshelf-serializer": "2.1.0",
     "hapi-format-error": "^2.1.0",
-    "joi": "12",
+    "@hapi/joi": "15.1.1",
     "knex": "^0.20.1",
     "pg": "^7.12.1"
   }

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Controller = require('../../../../lib/plugins/features/movies/controller');
+const Knex       = require('../../../../lib/libraries/knex');
 
 describe('movie controller', () => {
 
@@ -12,6 +13,78 @@ describe('movie controller', () => {
       const movie = await Controller.create(payload);
 
       expect(movie.get('title')).to.eql(payload.title);
+
+      await Knex('movies').truncate();
+    });
+
+  });
+
+  describe('get', () => {
+
+    describe('retrieves all matching movies', () => {
+
+      before(async () => {
+        const payload1 = { title: 'Mrs. Doubtfire', release_year: '1993' };
+        const payload2 = { title: 'Mrs. Doubtfire 2: Electric Boogaloo', release_year: '2103' };
+
+        await Controller.create(payload1);
+        await Controller.create(payload2);
+      });
+
+      after(async () => {
+        await Knex('movies').truncate();
+      });
+
+      it('filtered by start year', async () => {
+        const request = { query: {
+          startYear: 2100
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire 2: Electric Boogaloo');
+        expect(movies.models[0].get('release_year')).to.eql(2103);
+      });
+
+      it('filtered by end year', async () => {
+        const request = { query: {
+          endYear: 2000
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire');
+        expect(movies.models[0].get('release_year')).to.eql(1993);
+      });
+
+      it('filtered by fuzzy search on the title', async () => {
+        const request = { query: {
+          exact: 'false',
+          title: 'Electric'
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire 2: Electric Boogaloo');
+        expect(movies.models[0].get('release_year')).to.eql(2103);
+      });
+
+      it('filtered by exact search on the title', async () => {
+        const request = { query: {
+          exact: 'true',
+          title: 'Mrs. Doubtfire'
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire');
+        expect(movies.models[0].get('release_year')).to.eql(1993);
+      });
+
     });
 
   });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -5,7 +5,7 @@ const Knex       = require('../../../../lib/libraries/knex');
 
 describe('movie controller', () => {
 
-  before(async () => {
+  beforeEach(async () => {
     await Knex('movies').truncate();
   });
 
@@ -17,8 +17,6 @@ describe('movie controller', () => {
       const movie = await Controller.create(payload);
 
       expect(movie.get('title')).to.eql(payload.title);
-
-      await Knex('movies').truncate();
     });
 
   });
@@ -27,7 +25,7 @@ describe('movie controller', () => {
 
     describe('retrieves all matching movies', () => {
 
-      before(async () => {
+      beforeEach(async () => {
         const payload1 = { title: 'Mrs. Doubtfire', release_year: '1993' };
         const payload2 = { title: 'Mrs. Doubtfire 2: Electric Boogaloo', release_year: '2103' };
 

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -37,7 +37,10 @@ describe('movie controller', () => {
 
       it('filtered by start year', async () => {
         const request = { query: {
-          startYear: 2100
+          exact: false,
+          title: '',
+          startYear: 2100,
+          endYear: 9999
         } };
 
         const movies = await Controller.get(request);
@@ -49,6 +52,9 @@ describe('movie controller', () => {
 
       it('filtered by end year', async () => {
         const request = { query: {
+          exact: false,
+          title: '',
+          startYear: 1878,
           endYear: 2000
         } };
 
@@ -62,7 +68,9 @@ describe('movie controller', () => {
       it('filtered by fuzzy search on the title', async () => {
         const request = { query: {
           exact: 'false',
-          title: 'Electric'
+          title: 'Electric',
+          startYear: 1878,
+          endYear: 9999
         } };
 
         const movies = await Controller.get(request);
@@ -75,7 +83,9 @@ describe('movie controller', () => {
       it('filtered by exact search on the title', async () => {
         const request = { query: {
           exact: 'true',
-          title: 'Mrs. Doubtfire'
+          title: 'Mrs. Doubtfire',
+          startYear: 1878,
+          endYear: 9999
         } };
 
         const movies = await Controller.get(request);

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -5,6 +5,10 @@ const Knex       = require('../../../../lib/libraries/knex');
 
 describe('movie controller', () => {
 
+  before(async () => {
+    await Knex('movies').truncate();
+  });
+
   describe('create', () => {
 
     it('creates a movie', async () => {
@@ -29,10 +33,6 @@ describe('movie controller', () => {
 
         await Controller.create(payload1);
         await Controller.create(payload2);
-      });
-
-      after(async () => {
-        await Knex('movies').truncate();
       });
 
       it('filtered by start year', async () => {
@@ -82,10 +82,27 @@ describe('movie controller', () => {
 
       it('filtered by exact search on the title', async () => {
         const request = { query: {
-          exact: 'true',
+          exactTitle: 'true',
           title: 'Mrs. Doubtfire',
           startYear: 1878,
           endYear: 9999
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire');
+        expect(movies.models[0].get('release_year')).to.eql(1993);
+      });
+
+      it('filtered by exact search on the year', async () => {
+        const request = { query: {
+          exactTitle: 'false',
+          exactYear: 'true',
+          title: 'Mrs. Doubtfire',
+          startYear: 1878,
+          endYear: 9999,
+          year: 1993
         } };
 
         const movies = await Controller.get(request);

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -65,7 +65,7 @@ describe('movie controller', () => {
 
       it('filtered by fuzzy search on the title', async () => {
         const request = { query: {
-          exact: 'false',
+          exact: false,
           title: 'Electric',
           startYear: 1878,
           endYear: 9999
@@ -80,7 +80,7 @@ describe('movie controller', () => {
 
       it('filtered by exact search on the title', async () => {
         const request = { query: {
-          exactTitle: 'true',
+          exact: true,
           title: 'Mrs. Doubtfire',
           startYear: 1878,
           endYear: 9999
@@ -95,7 +95,7 @@ describe('movie controller', () => {
 
       it('filtered by exact search on the year', async () => {
         const request = { query: {
-          exactTitle: 'false',
+          exact: false,
           exactYear: 'true',
           title: 'Mrs. Doubtfire',
           startYear: 1878,

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -5,6 +5,10 @@ const Knex   = require('../../../../lib/libraries/knex');
 
 describe('movies integration', () => {
 
+  before(async () => {
+    await Knex('movies').truncate();
+  });
+
   describe('create', () => {
 
     it('creates a movie', async () => {

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Movies = require('../../../../lib/server');
+const Knex   = require('../../../../lib/libraries/knex');
 
 describe('movies integration', () => {
 
@@ -15,6 +16,21 @@ describe('movies integration', () => {
       expect(response.statusCode).to.eql(200);
       expect(response.result.object).to.eql('movie');
       expect(response.result.title).to.eql('Volver');
+
+      await Knex.truncate('movies');
+    });
+
+  });
+
+  describe('get', () => {
+
+    it('retrieves movies', async () => {
+      const response1 = await Movies.inject({
+        url: '/movies',
+        method: 'GET'
+      });
+
+      expect(response1.statusCode).to.eql(200);
     });
 
   });

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -5,7 +5,7 @@ const Knex   = require('../../../../lib/libraries/knex');
 
 describe('movies integration', () => {
 
-  before(async () => {
+  beforeEach(async () => {
     await Knex('movies').truncate();
   });
 
@@ -20,8 +20,6 @@ describe('movies integration', () => {
       expect(response.statusCode).to.eql(200);
       expect(response.result.object).to.eql('movie');
       expect(response.result.title).to.eql('Volver');
-
-      await Knex.truncate('movies');
     });
 
   });

--- a/test/validators/getMovie.test.js
+++ b/test/validators/getMovie.test.js
@@ -1,40 +1,22 @@
 'use strict';
 
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 const GetMovieValidator = require('../../lib/validators/getMovie');
 
 describe('get movie validator', () => {
 
-  describe('exactTitle', () => {
+  describe('exact', () => {
 
     it('defaults to false', () => {
       const query = {};
       const result = Joi.validate(query, GetMovieValidator);
 
-      expect(result.value.exactTitle).to.eql(false);
+      expect(result.value.exact).to.eql(false);
     });
 
     it('accepts true or false', () => {
-      const query = { exactTitle: 'maybe' };
-      const result = Joi.validate(query, GetMovieValidator);
-
-      expect(result.error.details[0].type).to.eql('boolean.base');
-    });
-
-  });
-
-  describe('exactYear', () => {
-
-    it('defaults to false', () => {
-      const query = {};
-      const result = Joi.validate(query, GetMovieValidator);
-
-      expect(result.value.exactYear).to.eql(false);
-    });
-
-    it('accepts true or false', () => {
-      const query = { exactYear: 'maybe' };
+      const query = { exact: 'maybe' };
       const result = Joi.validate(query, GetMovieValidator);
 
       expect(result.error.details[0].type).to.eql('boolean.base');
@@ -62,13 +44,6 @@ describe('get movie validator', () => {
 
   describe('startYear', () => {
 
-    it('defaults to 1878', () => {
-      const query = {};
-      const result = Joi.validate(query, GetMovieValidator);
-
-      expect(result.value.startYear).to.eql(1878);
-    });
-
     it('is after 1878', () => {
       const query = { startYear: 1000 };
       const result = Joi.validate(query, GetMovieValidator);
@@ -86,13 +61,6 @@ describe('get movie validator', () => {
   });
 
   describe('endYear', () => {
-
-    it('defaults to 9999', () => {
-      const query = {};
-      const result = Joi.validate(query, GetMovieValidator);
-
-      expect(result.value.endYear).to.eql(9999);
-    });
 
     it('is before 9999', () => {
       const query = { endYear: 99999 };
@@ -113,45 +81,45 @@ describe('get movie validator', () => {
   describe('year', () => {
 
     it('is a number', () => {
-      const query = { exactYear: true, year: 'Hoopla' };
+      const query = { year: 'Hoopla' };
       const result = Joi.validate(query, GetMovieValidator);
 
       expect(result.error.details[0].type).to.eql('number.base');
     });
 
     it('is an integer', () => {
-      const query = { exactYear: true, year: 1996.6 };
+      const query = { year: 1996.6 };
       const result = Joi.validate(query, GetMovieValidator);
 
       expect(result.error.details[0].type).to.eql('number.integer');
     });
 
     it('is after 1878', () => {
-      const query = { exactYear: true,  year: 1000 };
+      const query = {  year: 1000 };
       const result = Joi.validate(query, GetMovieValidator);
 
       expect(result.error.details[0].type).to.eql('number.min');
     });
 
     it('is before 9999', () => {
-      const query = { exactYear: true, year: 99999 };
+      const query = { year: 99999 };
       const result = Joi.validate(query, GetMovieValidator);
 
       expect(result.error.details[0].type).to.eql('number.max');
     });
 
-    it('is required if exactYear is true', () => {
-      const query = { exactYear: true };
+    it('cannot be present alongside startYear', () => {
+      const query = { year: 1950, startYear: 1952 };
       const result = Joi.validate(query, GetMovieValidator);
 
-      expect(result.error.details[0].type).to.eql('any.required');
+      expect(result.error.details[0].type).to.eql('object.oxor');
     });
 
-    it('is optional if exactYear is false', () => {
-      const query = { exactYear: false };
+    it('cannot be present alongside endYear', () => {
+      const query = { year: 1950, endYear: 1952 };
       const result = Joi.validate(query, GetMovieValidator);
 
-      expect(result.error).to.be.null;
+      expect(result.error.details[0].type).to.eql('object.oxor');
     });
 
   });

--- a/test/validators/getMovie.test.js
+++ b/test/validators/getMovie.test.js
@@ -6,17 +6,35 @@ const GetMovieValidator = require('../../lib/validators/getMovie');
 
 describe('get movie validator', () => {
 
-  describe('exact', () => {
+  describe('exactTitle', () => {
 
     it('defaults to false', () => {
       const query = {};
       const result = Joi.validate(query, GetMovieValidator);
 
-      expect(result.value.exact).to.eql(false);
+      expect(result.value.exactTitle).to.eql(false);
     });
 
     it('accepts true or false', () => {
-      const query = { exact: 'maybe' };
+      const query = { exactTitle: 'maybe' };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('boolean.base');
+    });
+
+  });
+
+  describe('exactYear', () => {
+
+    it('defaults to false', () => {
+      const query = {};
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.value.exactYear).to.eql(false);
+    });
+
+    it('accepts true or false', () => {
+      const query = { exactYear: 'maybe' };
       const result = Joi.validate(query, GetMovieValidator);
 
       expect(result.error.details[0].type).to.eql('boolean.base');
@@ -33,7 +51,7 @@ describe('get movie validator', () => {
       expect(result.value.title).to.eql('');
     });
 
-    it('must be shorter than 255 characters', () => {
+    it('is shorter than 255 characters', () => {
       const query = { title: 'a'.repeat(256) };
       const result = Joi.validate(query, GetMovieValidator);
 
@@ -51,11 +69,18 @@ describe('get movie validator', () => {
       expect(result.value.startYear).to.eql(1878);
     });
 
-    it('must be after 1878', () => {
+    it('is after 1878', () => {
       const query = { startYear: 1000 };
       const result = Joi.validate(query, GetMovieValidator);
 
       expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is an integer', () => {
+      const query = { endYear: 1996.6 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.integer');
     });
 
   });
@@ -69,11 +94,64 @@ describe('get movie validator', () => {
       expect(result.value.endYear).to.eql(9999);
     });
 
-    it('must be before 9999', () => {
+    it('is before 9999', () => {
       const query = { endYear: 99999 };
       const result = Joi.validate(query, GetMovieValidator);
 
       expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+    it('is an integer', () => {
+      const query = { endYear: 1996.6 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.integer');
+    });
+
+  });
+
+  describe('year', () => {
+
+    it('is a number', () => {
+      const query = { exactYear: true, year: 'Hoopla' };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.base');
+    });
+
+    it('is an integer', () => {
+      const query = { exactYear: true, year: 1996.6 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.integer');
+    });
+
+    it('is after 1878', () => {
+      const query = { exactYear: true,  year: 1000 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is before 9999', () => {
+      const query = { exactYear: true, year: 99999 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+    it('is required if exactYear is true', () => {
+      const query = { exactYear: true };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it('is optional if exactYear is false', () => {
+      const query = { exactYear: false };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error).to.be.null;
     });
 
   });

--- a/test/validators/getMovie.test.js
+++ b/test/validators/getMovie.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const Joi = require('joi');
+
+const GetMovieValidator = require('../../lib/validators/getMovie');
+
+describe('get movie validator', () => {
+
+  describe('exact', () => {
+
+    it('defaults to false', () => {
+      const query = {};
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.value.exact).to.eql(false);
+    });
+
+    it('accepts true or false', () => {
+      const query = { exact: 'maybe' };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('boolean.base');
+    });
+
+  });
+
+  describe('title', () => {
+
+    it('defaults to empty string', () => {
+      const query = {};
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.value.title).to.eql('');
+    });
+
+    it('must be shorter than 255 characters', () => {
+      const query = { title: 'a'.repeat(256) };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
+  describe('startYear', () => {
+
+    it('defaults to 1878', () => {
+      const query = {};
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.value.startYear).to.eql(1878);
+    });
+
+    it('must be after 1878', () => {
+      const query = { startYear: 1000 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+  });
+
+  describe('endYear', () => {
+
+    it('defaults to 9999', () => {
+      const query = {};
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.value.endYear).to.eql(9999);
+    });
+
+    it('must be before 9999', () => {
+      const query = { endYear: 99999 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+  });
+
+});

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 const MovieValidator = require('../../lib/validators/movie');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,38 @@
 # yarn lockfile v1
 
 
+"@hapi/address@2.x.x":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
+  integrity sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==
+
+"@hapi/bourne@1.x.x":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
+  integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
+
+"@hapi/hoek@8.x.x", "@hapi/hoek@^8.3.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.0.tgz#2f9ce301c8898e1c3248b0a8564696b24d1a9a5a"
+  integrity sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==
+
+"@hapi/joi@15.1.1":
+  version "15.1.1"
+  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.1.1.tgz#c675b8a71296f02833f8d6d243b34c57b8ce19d7"
+  integrity sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==
+  dependencies:
+    "@hapi/address" "2.x.x"
+    "@hapi/bourne" "1.x.x"
+    "@hapi/hoek" "8.x.x"
+    "@hapi/topo" "3.x.x"
+
+"@hapi/topo@3.x.x":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.6.tgz#68d935fa3eae7fdd5ab0d7f953f3205d8b2bfc29"
+  integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
+  dependencies:
+    "@hapi/hoek" "^8.3.0"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -1858,7 +1890,7 @@ joi@10.x.x:
     items "2.x.x"
     topo "2.x.x"
 
-joi@12, joi@12.x.x:
+joi@12.x.x:
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/joi/-/joi-12.0.0.tgz#46f55e68f4d9628f01bbb695902c8b307ad8d33a"
   integrity sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==


### PR DESCRIPTION
What: Add GET /movies endpoint
Why: We want to be able to filter movies by release year and title
Details:
* Adds a get function to the controller
* Adds appropriates Controller and Integration tests
* Fixes previous error where I wasn't cleaning up test data

Notes: 
* `feat(rename_title): Add NAME column to database migration` is reviewed in #7 
* `feat(rename_title): Backfill NAME column` is reviewed in #8 
* `feat(rename_title): Drop Title Column and Add Constraint to Name Column` is reviewed in #9 