### PR TITLE
feat(add_locations_constraint): Add Locations Constraint

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach",
+      "port": 9229
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "program": "${workspaceFolder}/lib/index.js"
+    }
+  ]
+}

--- a/db/migrations/20191111101834_drop_title_from_movies.js
+++ b/db/migrations/20191111101834_drop_title_from_movies.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = (knex) => {
+  return knex.schema.table('movies', (table) => {
+    table.dropColumn('title');
+  })
+  .then(() => {
+    return knex.raw('ALTER TABLE movies ADD CONSTRAINT movies_name_not_null CHECK (name IS NOT NULL) NOT VALID')
+    .then(() => {
+      return knex.raw('ALTER TABLE movies VALIDATE CONSTRAINT movies_name_not_null');
+    });
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.table('movies', (table) => {
+    table.text('title');
+  })
+  .then(() => {
+    return knex.raw('ALTER TABLE movies DROP CONSTRAINT movies_name_not_null');
+  });
+};

--- a/db/migrations/20191113090853_add_location_column.js
+++ b/db/migrations/20191113090853_add_location_column.js
@@ -1,0 +1,11 @@
+'use strict';
+
+exports.up = async (knex) => {
+  await knex.raw('ALTER TABLE movies ADD COLUMN locations text[]');
+};
+
+exports.down = async (knex) => {
+  await knex.schema.table('movies', (table) => {
+    table.dropColumn('locations');
+  });
+};

--- a/db/migrations/20191113093239_backfill_locations.js
+++ b/db/migrations/20191113093239_backfill_locations.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = (knex) => {
+  return knex.raw('UPDATE movies SET locations = \'{San Francisco}\'');
+};
+
+exports.down = (knex, Promise) => {
+  return Promise.resolve();
+};

--- a/db/migrations/20191114094355_add_locations_constraint.js
+++ b/db/migrations/20191114094355_add_locations_constraint.js
@@ -1,0 +1,12 @@
+'use strict';
+
+exports.up = function (knex) {
+  return knex.raw('ALTER TABLE movies ADD CONSTRAINT movies_locations_not_null CHECK (locations IS NOT NULL) NOT VALID')
+  .then(() => {
+    return knex.raw('ALTER TABLE movies VALIDATE CONSTRAINT movies_locations_not_null');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.raw('ALTER TABLE movies DROP CONSTRAINT movies_name_not_null');
+};

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -7,7 +7,7 @@ module.exports = Bookshelf.Model.extend({
   serialize: function () {
     return {
       id: this.get('id'),
-      title: this.get('title'),
+      title: this.get('name'),
       release_year: this.get('release_year'),
       object: 'movie'
     };

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -9,6 +9,7 @@ module.exports = Bookshelf.Model.extend({
       id: this.get('id'),
       title: this.get('name'),
       release_year: this.get('release_year'),
+      locations: this.get('locations'),
       object: 'movie'
     };
   }

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,7 +3,10 @@
 const Movie = require('../../../models/movie');
 
 exports.create = async (payload) => {
-  const movie = await Movie.forge({ name: payload.title }).save(payload);
+  const name = payload.title;
+  Reflect.deleteProperty(payload, 'title');
+
+  const movie = await Movie.forge({ name }).save(payload);
 
   return new Movie({ id: movie.id }).fetch();
 };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -10,3 +10,25 @@ exports.create = async (payload) => {
 
   return new Movie({ id: movie.id }).fetch();
 };
+
+exports.get = async (request) => {
+  const params = request.query;
+
+  return await new Movie().query((builder) => {
+    const matcher = params.exact === 'true' ? '=' : 'LIKE';
+
+    let title;
+
+    if (matcher === '=') {
+      title = params.title;
+    } else {
+      title = `%${params.title ? params.title : ''}%`;
+    }
+
+    builder
+    .where('release_year', '>', params.startYear ? params.startYear : '1878')
+    .andWhere('release_year', '<', params.endYear ? params.endYear :  '9999')
+    .andWhere('name', matcher, title);
+  })
+  .fetchAll();
+};

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -15,20 +15,24 @@ exports.get = async (request) => {
   const params = request.query;
 
   return await new Movie().query((builder) => {
-    const matcher = params.exact === 'true' ? '=' : 'LIKE';
+    const titleMatcher = params.exactTitle === 'true' ? '=' : 'LIKE';
 
     let title;
 
-    if (matcher === '=') {
+    if (titleMatcher === '=') {
       title = params.title;
     } else {
       title = `%${params.title}%`;
     }
 
-    builder
-    .where('release_year', '>=', params.startYear)
-    .andWhere('release_year', '<=', params.endYear)
-    .andWhere('name', matcher, title);
+    if (params.exactYear) {
+      builder.where('release_year', '=', params.year);
+    } else {
+      builder
+      .where('release_year', '>=', params.startYear)
+      .where('release_year', '<=', params.endYear);
+    }
+    builder.where('name', titleMatcher, title);
   })
   .fetchAll();
 };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -22,12 +22,12 @@ exports.get = async (request) => {
     if (matcher === '=') {
       title = params.title;
     } else {
-      title = `%${params.title ? params.title : ''}%`;
+      title = `%${params.title}%`;
     }
 
     builder
-    .where('release_year', '>', params.startYear ? params.startYear : '1878')
-    .andWhere('release_year', '<', params.endYear ? params.endYear :  '9999')
+    .where('release_year', '>=', params.startYear)
+    .andWhere('release_year', '<=', params.endYear)
     .andWhere('name', matcher, title);
   })
   .fetchAll();

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -36,3 +36,13 @@ exports.get = async (request) => {
   })
   .fetchAll();
 };
+
+exports.updateLocations = async (request) => {
+  const id = request.params.id;
+
+  const movie = await new Movie({ id }).fetch();
+
+  return await Movie.forge({ locations: movie.attributes.locations.concat(request.payload.locations) })
+  .where('id', '=', id)
+  .save(null, { method: 'update' });
+};

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -25,6 +25,16 @@ exports.get = async (request) => {
       title = `%${params.title}%`;
     }
 
+    const locationMatcher = params.exactLocation === 'true' ? '=' : 'LIKE';
+
+    let location;
+
+    if (locationMatcher === '=') {
+      location = params.location;
+    } else {
+      location = `%${params.location ? params.location : ''}%`;
+    }
+
     if (params.exactYear) {
       builder.where('release_year', '=', params.year);
     } else {
@@ -32,7 +42,9 @@ exports.get = async (request) => {
       .where('release_year', '>=', params.startYear)
       .where('release_year', '<=', params.endYear);
     }
-    builder.where('name', titleMatcher, title);
+    builder
+    .where('name', titleMatcher, title)
+    .whereRaw(`EXISTS (SELECT FROM unnest(locations) location WHERE location ${locationMatcher} '${location}')`);
   })
   .fetchAll();
 };

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const Controller     = require('./controller');
-const MovieValidator = require('../../../validators/movie');
+const Controller        = require('./controller');
+const MovieValidator    = require('../../../validators/movie');
+const MovieGetValidator = require('../../../validators/getMovie');
 
 exports.register = (server, options, next) => {
   server.route([{
@@ -23,6 +24,9 @@ exports.register = (server, options, next) => {
     config: {
       handler: (request, reply) => {
         reply(Controller.get(request));
+      },
+      validate: {
+        query: MovieGetValidator
       }
     }
   }]);

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -31,6 +31,19 @@ exports.register = (server, options, next) => {
     }
   }]);
 
+  server.route([{
+    method: 'POST',
+    path: '/movies/{id}/locations',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.updateLocations(request));
+      },
+      validate: {
+        payload: LocationValidator
+      }
+    }
+  }]);
+
   next();
 
 };

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -17,6 +17,16 @@ exports.register = (server, options, next) => {
     }
   }]);
 
+  server.route([{
+    method: 'GET',
+    path: '/movies',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.get(request));
+      }
+    }
+  }]);
+
   next();
 
 };

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -3,6 +3,7 @@
 const Controller        = require('./controller');
 const MovieValidator    = require('../../../validators/movie');
 const MovieGetValidator = require('../../../validators/getMovie');
+const LocationValidator = require('../../../validators/location');
 
 exports.register = (server, options, next) => {
   server.route([{
@@ -27,6 +28,19 @@ exports.register = (server, options, next) => {
       },
       validate: {
         query: MovieGetValidator
+      }
+    }
+  }]);
+
+  server.route([{
+    method: 'POST',
+    path: '/movies/{id}/locations',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.updateLocations(request));
+      },
+      validate: {
+        payload: LocationValidator
       }
     }
   }]);

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -45,19 +45,6 @@ exports.register = (server, options, next) => {
     }
   }]);
 
-  server.route([{
-    method: 'POST',
-    path: '/movies/{id}/locations',
-    config: {
-      handler: (request, reply) => {
-        reply(Controller.updateLocations(request));
-      },
-      validate: {
-        payload: LocationValidator
-      }
-    }
-  }]);
-
   next();
 
 };

--- a/lib/validators/getMovie.js
+++ b/lib/validators/getMovie.js
@@ -5,9 +5,11 @@ const Joi = require('joi');
 module.exports = Joi.object().keys({
   exactTitle: Joi.boolean().default(false),
   exactYear: Joi.boolean().default(false),
+  exactLocation: Joi.boolean().default(false),
   title: Joi.string().min(1).max(255).default(''),
   startYear: Joi.number().integer().min(1878).default(1878),
   endYear: Joi.number().integer().max(9999).default(9999),
+  locations: Joi.string().max(255).default(''),
   year: Joi.when(Joi.ref('exactYear'), {
     is: Joi.boolean().valid(true).required(),
     then: Joi.number().integer().min(1878).max(9999).required(),

--- a/lib/validators/getMovie.js
+++ b/lib/validators/getMovie.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = {
+  exact: Joi.boolean().default(false),
+  title: Joi.string().min(1).max(255).default(''),
+  startYear: Joi.number().min(1878).default(1878),
+  endYear: Joi.number().max(9999).default(9999)
+};

--- a/lib/validators/getMovie.js
+++ b/lib/validators/getMovie.js
@@ -2,9 +2,15 @@
 
 const Joi = require('joi');
 
-module.exports = {
-  exact: Joi.boolean().default(false),
+module.exports = Joi.object().keys({
+  exactTitle: Joi.boolean().default(false),
+  exactYear: Joi.boolean().default(false),
   title: Joi.string().min(1).max(255).default(''),
-  startYear: Joi.number().min(1878).default(1878),
-  endYear: Joi.number().max(9999).default(9999)
-};
+  startYear: Joi.number().integer().min(1878).default(1878),
+  endYear: Joi.number().integer().max(9999).default(9999),
+  year: Joi.when(Joi.ref('exactYear'), {
+    is: Joi.boolean().valid(true).required(),
+    then: Joi.number().integer().min(1878).max(9999).required(),
+    otherwise: Joi.any()
+  })
+});

--- a/lib/validators/location.js
+++ b/lib/validators/location.js
@@ -3,7 +3,5 @@
 const Joi = require('joi');
 
 module.exports = Joi.object().keys({
-  title: Joi.string().min(1).max(255).required(),
-  release_year: Joi.number().integer().min(1878).max(9999).optional(),
   locations: Joi.array().min(1).items(Joi.string().min(1).max(255).required()).required()
 });

--- a/test/models/movie.test.js
+++ b/test/models/movie.test.js
@@ -11,6 +11,7 @@ describe('movie model', () => {
 
       expect(movie).to.have.all.keys([
         'id',
+        'locations',
         'title',
         'release_year',
         'object'

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Controller = require('../../../../lib/plugins/features/movies/controller');
+const Knex       = require('../../../../lib/libraries/knex');
 
 describe('movie controller', () => {
 
@@ -12,6 +13,78 @@ describe('movie controller', () => {
       const movie = await Controller.create(payload);
 
       expect(movie.get('title')).to.eql(payload.title);
+
+      await Knex('movies').truncate();
+    });
+
+  });
+
+  describe('get', () => {
+
+    describe('retrieves all matching movies', () => {
+
+      before(async () => {
+        const payload1 = { title: 'Mrs. Doubtfire', release_year: '1993' };
+        const payload2 = { title: 'Mrs. Doubtfire 2: Electric Boogaloo', release_year: '2103' };
+
+        await Controller.create(payload1);
+        await Controller.create(payload2);
+      });
+
+      after(async () => {
+        await Knex('movies').truncate();
+      });
+
+      it('filtered by start year', async () => {
+        const request = { query: {
+          startYear: 2100
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire 2: Electric Boogaloo');
+        expect(movies.models[0].get('release_year')).to.eql(2103);
+      });
+
+      it('filtered by end year', async () => {
+        const request = { query: {
+          endYear: 2000
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire');
+        expect(movies.models[0].get('release_year')).to.eql(1993);
+      });
+
+      it('filtered by fuzzy search on the title', async () => {
+        const request = { query: {
+          exact: 'false',
+          title: 'Electric'
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire 2: Electric Boogaloo');
+        expect(movies.models[0].get('release_year')).to.eql(2103);
+      });
+
+      it('filtered by exact search on the title', async () => {
+        const request = { query: {
+          exact: 'true',
+          title: 'Mrs. Doubtfire'
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire');
+        expect(movies.models[0].get('release_year')).to.eql(1993);
+      });
+
     });
 
   });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -176,7 +176,7 @@ describe('movie controller', () => {
 
       await Knex('movies').truncate();
     });
-
+    
   });
 
 });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -37,7 +37,10 @@ describe('movie controller', () => {
 
       it('filtered by start year', async () => {
         const request = { query: {
-          startYear: 2100
+          exact: false,
+          title: '',
+          startYear: 2100,
+          endYear: 9999
         } };
 
         const movies = await Controller.get(request);
@@ -49,6 +52,9 @@ describe('movie controller', () => {
 
       it('filtered by end year', async () => {
         const request = { query: {
+          exact: false,
+          title: '',
+          startYear: 1878,
           endYear: 2000
         } };
 
@@ -62,7 +68,9 @@ describe('movie controller', () => {
       it('filtered by fuzzy search on the title', async () => {
         const request = { query: {
           exact: 'false',
-          title: 'Electric'
+          title: 'Electric',
+          startYear: 1878,
+          endYear: 9999
         } };
 
         const movies = await Controller.get(request);
@@ -75,7 +83,9 @@ describe('movie controller', () => {
       it('filtered by exact search on the title', async () => {
         const request = { query: {
           exact: 'true',
-          title: 'Mrs. Doubtfire'
+          title: 'Mrs. Doubtfire',
+          startYear: 1878,
+          endYear: 9999
         } };
 
         const movies = await Controller.get(request);

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -67,10 +67,10 @@ describe('movie controller', () => {
 
       it('filtered by fuzzy search on the title', async () => {
         const request = { query: {
-          exact: 'false',
-          title: 'Electric',
           startYear: 1878,
-          endYear: 9999
+          endYear: 9999,
+          exactTitle: 'false',
+          title: 'Electric'
         } };
 
         const movies = await Controller.get(request);
@@ -112,6 +112,40 @@ describe('movie controller', () => {
         expect(movies.models[0].get('release_year')).to.eql(1993);
       });
 
+      it('filtered by fuzzy search on the location', async () => {
+        const request = { query: {
+          exactLocation: 'false',
+          exactTitle: 'false',
+          title: '',
+          startYear: 1878,
+          endYear: 9999,
+          location: 'Die'
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire 2: Electric Boogaloo');
+        expect(movies.models[0].get('release_year')).to.eql(2103);
+      });
+
+      it('filtered by exact search on the location', async () => {
+        const request = { query: {
+          exactLocation: 'true',
+          exactTitle: 'false',
+          title: '',
+          startYear: 1878,
+          endYear: 9999,
+          location: 'San Francisco'
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire');
+        expect(movies.models[0].get('release_year')).to.eql(1993);
+      });
+
     });
 
   });
@@ -142,7 +176,7 @@ describe('movie controller', () => {
 
       await Knex('movies').truncate();
     });
-    
+
   });
 
 });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -5,6 +5,10 @@ const Knex       = require('../../../../lib/libraries/knex');
 
 describe('movie controller', () => {
 
+  before(async () => {
+    await Knex('movies').truncate();
+  });
+
   describe('create', () => {
 
     it('creates a movie', async () => {
@@ -29,10 +33,6 @@ describe('movie controller', () => {
 
         await Controller.create(payload1);
         await Controller.create(payload2);
-      });
-
-      after(async () => {
-        await Knex('movies').truncate();
       });
 
       it('filtered by start year', async () => {
@@ -82,10 +82,27 @@ describe('movie controller', () => {
 
       it('filtered by exact search on the title', async () => {
         const request = { query: {
-          exact: 'true',
+          exactTitle: 'true',
           title: 'Mrs. Doubtfire',
           startYear: 1878,
           endYear: 9999
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire');
+        expect(movies.models[0].get('release_year')).to.eql(1993);
+      });
+
+      it('filtered by exact search on the year', async () => {
+        const request = { query: {
+          exactTitle: 'false',
+          exactYear: 'true',
+          title: 'Mrs. Doubtfire',
+          startYear: 1878,
+          endYear: 9999,
+          year: 1993
         } };
 
         const movies = await Controller.get(request);

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -146,6 +146,32 @@ describe('movie controller', () => {
         expect(movies.models[0].get('release_year')).to.eql(1993);
       });
 
+      it('filtered by fuzzy search on the location', async () => {
+        const request = { query: {
+          exactLocation: 'false',
+          location: 'Die'
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire 2: Electric Boogaloo');
+        expect(movies.models[0].get('release_year')).to.eql(2103);
+      });
+
+      it('filtered by exact search on the location', async () => {
+        const request = { query: {
+          exactLocation: 'true',
+          location: 'San Francisco'
+        } };
+
+        const movies = await Controller.get(request);
+
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire');
+        expect(movies.models[0].get('release_year')).to.eql(1993);
+      });
+
     });
 
   });
@@ -176,7 +202,7 @@ describe('movie controller', () => {
 
       await Knex('movies').truncate();
     });
-    
+
   });
 
 });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -146,32 +146,6 @@ describe('movie controller', () => {
         expect(movies.models[0].get('release_year')).to.eql(1993);
       });
 
-      it('filtered by fuzzy search on the location', async () => {
-        const request = { query: {
-          exactLocation: 'false',
-          location: 'Die'
-        } };
-
-        const movies = await Controller.get(request);
-
-        expect(movies.models.length).to.eql(1);
-        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire 2: Electric Boogaloo');
-        expect(movies.models[0].get('release_year')).to.eql(2103);
-      });
-
-      it('filtered by exact search on the location', async () => {
-        const request = { query: {
-          exactLocation: 'true',
-          location: 'San Francisco'
-        } };
-
-        const movies = await Controller.get(request);
-
-        expect(movies.models.length).to.eql(1);
-        expect(movies.models[0].get('name')).to.eql('Mrs. Doubtfire');
-        expect(movies.models[0].get('release_year')).to.eql(1993);
-      });
-
     });
 
   });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -28,8 +28,8 @@ describe('movie controller', () => {
     describe('retrieves all matching movies', () => {
 
       before(async () => {
-        const payload1 = { title: 'Mrs. Doubtfire', release_year: '1993' };
-        const payload2 = { title: 'Mrs. Doubtfire 2: Electric Boogaloo', release_year: '2103' };
+        const payload1 = { title: 'Mrs. Doubtfire', release_year: '1993', locations: ['San Francisco'] };
+        const payload2 = { title: 'Mrs. Doubtfire 2: Electric Boogaloo', release_year: '2103', locations: ['San Diego'] };
 
         await Controller.create(payload1);
         await Controller.create(payload2);
@@ -114,6 +114,35 @@ describe('movie controller', () => {
 
     });
 
+  });
+
+  describe('updateLocation', () => {
+
+    it('updates a movie location', async () => {
+      const payload = { title: 'WALL-E', locations: ['Space'] };
+
+      const movie = await Controller.create(payload);
+
+      expect(movie.get('title')).to.eql(payload.title);
+      expect(movie.get('locations')).to.eql(payload.locations);
+
+      const request = {
+        params: {
+          id: movie.id
+        },
+        payload: {
+          locations: ['Earth']
+        }
+      };
+
+      const updatedMovie = await Controller.updateLocations(request);
+
+      expect(updatedMovie.get('title')).to.eql(payload.title);
+      expect(updatedMovie.get('locations')).to.eql(payload.locations.concat(request.payload.locations));
+
+      await Knex('movies').truncate();
+    });
+    
   });
 
 });

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -5,6 +5,10 @@ const Knex   = require('../../../../lib/libraries/knex');
 
 describe('movies integration', () => {
 
+  before(async () => {
+    await Knex('movies').truncate();
+  });
+
   describe('create', () => {
 
     it('creates a movie', async () => {

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -15,7 +15,7 @@ describe('movies integration', () => {
       const response = await Movies.inject({
         url: '/movies',
         method: 'POST',
-        payload: { title: 'Volver' }
+        payload: { title: 'Volver', locations: ['San Francisco'] }
       });
       expect(response.statusCode).to.eql(200);
       expect(response.result.object).to.eql('movie');
@@ -35,6 +35,34 @@ describe('movies integration', () => {
       });
 
       expect(response1.statusCode).to.eql(200);
+    });
+
+  });
+
+  describe('update', () => {
+
+    it('updates movie locations', async () => {
+      const response = await Movies.inject({
+        url: '/movies',
+        method: 'POST',
+        payload: { title: 'Volver', locations: ['San Francisco'] }
+      });
+      expect(response.statusCode).to.eql(200);
+      expect(response.result.object).to.eql('movie');
+      expect(response.result.title).to.eql('Volver');
+      expect(response.result.locations).to.eql(['San Francisco']);
+
+      const updatedResponse = await Movies.inject({
+        url: `/movies/${response.result.id}/locations`,
+        method: 'POST',
+        payload: { locations: ['San Fernando'] }
+      });
+      expect(updatedResponse.statusCode).to.eql(200);
+      expect(updatedResponse.result.object).to.eql('movie');
+      expect(updatedResponse.result.title).to.eql('Volver');
+      expect(updatedResponse.result.locations).to.eql(['San Francisco', 'San Fernando']);
+
+      await Knex.truncate('movies');
     });
 
   });

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Movies = require('../../../../lib/server');
+const Knex   = require('../../../../lib/libraries/knex');
 
 describe('movies integration', () => {
 
@@ -15,6 +16,21 @@ describe('movies integration', () => {
       expect(response.statusCode).to.eql(200);
       expect(response.result.object).to.eql('movie');
       expect(response.result.title).to.eql('Volver');
+
+      await Knex.truncate('movies');
+    });
+
+  });
+
+  describe('get', () => {
+
+    it('retrieves movies', async () => {
+      const response1 = await Movies.inject({
+        url: '/movies',
+        method: 'GET'
+      });
+
+      expect(response1.statusCode).to.eql(200);
     });
 
   });

--- a/test/validators/getMovie.test.js
+++ b/test/validators/getMovie.test.js
@@ -6,17 +6,35 @@ const GetMovieValidator = require('../../lib/validators/getMovie');
 
 describe('get movie validator', () => {
 
-  describe('exact', () => {
+  describe('exactTitle', () => {
 
     it('defaults to false', () => {
       const query = {};
       const result = Joi.validate(query, GetMovieValidator);
 
-      expect(result.value.exact).to.eql(false);
+      expect(result.value.exactTitle).to.eql(false);
     });
 
     it('accepts true or false', () => {
-      const query = { exact: 'maybe' };
+      const query = { exactTitle: 'maybe' };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('boolean.base');
+    });
+
+  });
+
+  describe('exactYear', () => {
+
+    it('defaults to false', () => {
+      const query = {};
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.value.exactYear).to.eql(false);
+    });
+
+    it('accepts true or false', () => {
+      const query = { exactYear: 'maybe' };
       const result = Joi.validate(query, GetMovieValidator);
 
       expect(result.error.details[0].type).to.eql('boolean.base');
@@ -33,7 +51,7 @@ describe('get movie validator', () => {
       expect(result.value.title).to.eql('');
     });
 
-    it('must be shorter than 255 characters', () => {
+    it('is shorter than 255 characters', () => {
       const query = { title: 'a'.repeat(256) };
       const result = Joi.validate(query, GetMovieValidator);
 
@@ -51,11 +69,18 @@ describe('get movie validator', () => {
       expect(result.value.startYear).to.eql(1878);
     });
 
-    it('must be after 1878', () => {
+    it('is after 1878', () => {
       const query = { startYear: 1000 };
       const result = Joi.validate(query, GetMovieValidator);
 
       expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is an integer', () => {
+      const query = { endYear: 1996.6 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.integer');
     });
 
   });
@@ -69,11 +94,64 @@ describe('get movie validator', () => {
       expect(result.value.endYear).to.eql(9999);
     });
 
-    it('must be before 9999', () => {
+    it('is before 9999', () => {
       const query = { endYear: 99999 };
       const result = Joi.validate(query, GetMovieValidator);
 
       expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+    it('is an integer', () => {
+      const query = { endYear: 1996.6 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.integer');
+    });
+
+  });
+
+  describe('year', () => {
+
+    it('is a number', () => {
+      const query = { exactYear: true, year: 'Hoopla' };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.base');
+    });
+
+    it('is an integer', () => {
+      const query = { exactYear: true, year: 1996.6 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.integer');
+    });
+
+    it('is after 1878', () => {
+      const query = { exactYear: true,  year: 1000 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is before 9999', () => {
+      const query = { exactYear: true, year: 99999 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+    it('is required if exactYear is true', () => {
+      const query = { exactYear: true };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it('is optional if exactYear is false', () => {
+      const query = { exactYear: false };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error).to.be.null;
     });
 
   });

--- a/test/validators/getMovie.test.js
+++ b/test/validators/getMovie.test.js
@@ -42,6 +42,24 @@ describe('get movie validator', () => {
 
   });
 
+  describe('exactLocation', () => {
+
+    it('defaults to false', () => {
+      const query = {};
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.value.exactLocation).to.eql(false);
+    });
+
+    it('accepts true or false', () => {
+      const query = { exactLocation: 'maybe' };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('boolean.base');
+    });
+
+  });
+
   describe('title', () => {
 
     it('defaults to empty string', () => {
@@ -106,6 +124,24 @@ describe('get movie validator', () => {
       const result = Joi.validate(query, GetMovieValidator);
 
       expect(result.error.details[0].type).to.eql('number.integer');
+    });
+
+  });
+
+  describe('location', () => {
+
+    it('defaults to empty string', () => {
+      const query = {};
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.value.title).to.eql('');
+    });
+
+    it('is shorter than 255 characters', () => {
+      const query = { title: 'a'.repeat(256) };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('string.max');
     });
 
   });

--- a/test/validators/getMovie.test.js
+++ b/test/validators/getMovie.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const Joi = require('joi');
+
+const GetMovieValidator = require('../../lib/validators/getMovie');
+
+describe('get movie validator', () => {
+
+  describe('exact', () => {
+
+    it('defaults to false', () => {
+      const query = {};
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.value.exact).to.eql(false);
+    });
+
+    it('accepts true or false', () => {
+      const query = { exact: 'maybe' };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('boolean.base');
+    });
+
+  });
+
+  describe('title', () => {
+
+    it('defaults to empty string', () => {
+      const query = {};
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.value.title).to.eql('');
+    });
+
+    it('must be shorter than 255 characters', () => {
+      const query = { title: 'a'.repeat(256) };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
+  describe('startYear', () => {
+
+    it('defaults to 1878', () => {
+      const query = {};
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.value.startYear).to.eql(1878);
+    });
+
+    it('must be after 1878', () => {
+      const query = { startYear: 1000 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+  });
+
+  describe('endYear', () => {
+
+    it('defaults to 9999', () => {
+      const query = {};
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.value.endYear).to.eql(9999);
+    });
+
+    it('must be before 9999', () => {
+      const query = { endYear: 99999 };
+      const result = Joi.validate(query, GetMovieValidator);
+
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+  });
+
+});

--- a/test/validators/location.test.js
+++ b/test/validators/location.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieValidator = require('../../lib/validators/location');
+
+describe('location validator', () => {
+
+  describe('locations', () => {
+
+    it('is required', () => {
+      const payload = { title: 'title', release_year: 1951 };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('locations');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it('is an array', () => {
+      const payload = { title: 'title', release_year: 1951, locations: 'San Francisco' };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('locations');
+      expect(result.error.details[0].type).to.eql('array.base');
+    });
+
+    it('is an array with items', () => {
+      const payload = { title: 'title', release_year: 1951, locations: [] };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('locations');
+      expect(result.error.details[0].type).to.eql('array.includesRequiredUnknowns');
+    });
+
+    it('is an array of strings', () => {
+      const payload = { title: 'title', release_year: 1951, locations: [1951] };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('locations');
+      expect(result.error.details[0].type).to.eql('string.base');
+    });
+
+  });
+
+});

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -54,4 +54,40 @@ describe('movie validator', () => {
 
   });
 
+  describe('locations', () => {
+
+    it('is required', () => {
+      const payload = { title: 'title', release_year: 1951 };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('locations');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it('is an array', () => {
+      const payload = { title: 'title', release_year: 1951, locations: 'San Francisco' };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('locations');
+      expect(result.error.details[0].type).to.eql('array.base');
+    });
+
+    it('is an array with items', () => {
+      const payload = { title: 'title', release_year: 1951, locations: [] };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('locations');
+      expect(result.error.details[0].type).to.eql('array.includesRequiredUnknowns');
+    });
+
+    it('is an array of strings', () => {
+      const payload = { title: 'title', release_year: 1951, locations: [1951] };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('locations');
+      expect(result.error.details[0].type).to.eql('string.base');
+    });
+
+  });
+
 });


### PR DESCRIPTION
### What
* Adds the Not Null constraint to the Locations column
### Why
* Because the locations column is required, it must be not null
### Details
* Adds the Migration file to add the Locations constraint
### Notes
* `feat(rename_title)` reviewed in #9 
* `feat(get_movies)` reviewed in #10 
* `feat(multiple_locations)` reviewed in #11 
* `feat(backfill_columns)` and `feat(update_filters)` reviewed in #12 
